### PR TITLE
Reenable Help menu button, link to launch of GitHub Pages user manual

### DIFF
--- a/StoryBuilder/Views/Shell.xaml
+++ b/StoryBuilder/Views/Shell.xaml
@@ -212,7 +212,7 @@
                     </AppBarButton.Icon>
                 </AppBarButton>
                 <AppBarButton Label="Help" ToolTipService.ToolTip="Help"
-                              Command="{x:Bind ShellVm.HelpCommand, Mode=OneWay}" IsEnabled="False" >
+                              Command="{x:Bind ShellVm.HelpCommand, Mode=OneWay}" >
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE897;"/>
                     </AppBarButton.Icon>

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -1226,6 +1226,28 @@ namespace StoryBuilder.ViewModels
             _canExecuteCommands = true;
         }
 
+        private void LaunchGitHubPages()
+        {
+            _canExecuteCommands = false;
+            string msg = "Launching GitHub Pages User Manual";
+            Logger.Log(LogLevel.Info,msg);
+            StatusMessage = msg;
+
+            string url = @"https://storybuilder-org.github.io/StoryBuilder-2/";
+
+            ProcessStartInfo psi = new ProcessStartInfo
+            {
+                FileName = url,
+                UseShellExecute = true
+            };
+            Process.Start(psi);
+
+            msg = "Launch default browser completed";
+            StatusMessage = msg;
+            Logger.Log(LogLevel.Info, msg);
+            _canExecuteCommands = true;
+        }
+
         #endregion  
 
         #region Move TreeViewItem Commands
@@ -1872,15 +1894,19 @@ namespace StoryBuilder.ViewModels
 
             FilterCommand = new RelayCommand(SearchNodes, () => _canExecuteCommands);
 
+            // Tools commands
             KeyQuestionsCommand = new RelayCommand(KeyQuestionsTool, () => _canExecuteCommands);
             TopicsCommand = new RelayCommand(TopicsTool, () => _canExecuteCommands);
             MasterPlotsCommand = new RelayCommand(MasterPlotTool, () => _canExecuteCommands);
             DramaticSituationsCommand = new RelayCommand(DramaticSituationsTool, () => _canExecuteCommands);
             StockScenesCommand = new RelayCommand(StockScenesTool, () => _canExecuteCommands);
+
             PreferencesCommand = new RelayCommand(Preferences, () => _canExecuteCommands);
 
             PrintReportsCommand = new RelayCommand(GeneratePrintReports, () => _canExecuteCommands);
             ScrivenerReportsCommand = new RelayCommand(GenerateScrivenerReports, () => _canExecuteCommands);
+
+            HelpCommand = new RelayCommand(LaunchGitHubPages, () => _canExecuteCommands);
 
             // Move StoryElement commands
             MoveLeftCommand = new RelayCommand(MoveTreeViewItemLeft, () => _canExecuteCommands);

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Table of Contents
  
 [File Menu](File_Menu.md)
  
-[Add/Remove Story Elements](Add_Remove_Story_Elements.md)
+[Add or Remove Story Elements](Add_Remove_Story_Elements.md)
  
 [Move Story Elements](Move_Story_Elements.md)
  


### PR DESCRIPTION
With the manual formatting (more or less), this re-enables the ability to display the manual as the Help Button.