### PR TITLE
Fixed casing on elmah.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ and suspenseful plots, and settings that appeal to the senses.
 * [WinUI 3][1]
 * [Windows App SDK][2]
 * [Windows Community Toolkit][3]
-* [Elmah.io][4]
+* [elmah.io][4]
 * [NRtfTree][5]
 * [Scrivener][6]
 * [SyncFusion][7]


### PR DESCRIPTION
If you don't mind, I'll fix the casing on elmah.io to all lowercase since that is the correct company/product name.