### PR TITLE
Print all the documents in one go.

### DIFF
--- a/StoryBuilderLib/Services/Reports/PrintReports.cs
+++ b/StoryBuilderLib/Services/Reports/PrintReports.cs
@@ -32,40 +32,34 @@ public class PrintReports
         if (_vm.CreateOverview)
         {
             rtf = _formatter.FormatStoryOverviewReport(Overview());
-            documentText = FormatText(rtf);
-            Print(documentText);
+            documentText += FormatText(rtf);
         }
         if (_vm.CreateSummary)
         {
             rtf =_formatter.FormatSynopsisReport();
             //documentText = FormatText(rtf);
-            documentText = FormatText(rtf,true);
-            Print(documentText);
+            documentText += FormatText(rtf,true);
         }
 
         if (_vm.ProblemList)
         {
             rtf = _formatter.FormatProblemListReport();
-            documentText = FormatText(rtf);
-            Print(documentText);
+            documentText += FormatText(rtf);
         }
         if (_vm.CharacterList)
         {
             rtf = _formatter.FormatCharacterListReport();
-            documentText = FormatText(rtf);
-            Print(documentText);
+            documentText += FormatText(rtf);
         }
         if (_vm.SettingList)
         {
             rtf = _formatter.FormatSettingListReport();
-            documentText = FormatText(rtf);
-            Print(documentText);
+            documentText += FormatText(rtf);
         }
         if (_vm.SceneList)
         {
             rtf = _formatter.FormatSceneListReport();
-            documentText = FormatText(rtf);
-            Print(documentText);
+            documentText += FormatText(rtf);
         }
 
         foreach (StoryNodeItem node in _vm.SelectedNodes)
@@ -90,10 +84,11 @@ public class PrintReports
                         rtf = _formatter.FormatSceneReport(element);
                         break;
                 }
-                documentText = FormatText(rtf);
-                Print(documentText);
+                documentText += FormatText(rtf);
             }
         }
+
+        Print(documentText);
     }
 
     private StoryElement Overview() 
@@ -125,10 +120,8 @@ public class PrintReports
         }
 
         // If more lines exist, print another page.
-        if (line != null)
-            ev.HasMorePages = true;
-        else
-            ev.HasMorePages = false;
+        if (line != null) { ev.HasMorePages = true; }
+        else { ev.HasMorePages = false; }
     }
 
     // Print the file.
@@ -162,7 +155,7 @@ public class PrintReports
     /// <returns></returns>
     private string FormatText(string rtfInput, bool SummaryMode = false) 
     {
-        string text = _formatter.GetText(rtfInput, false);
+        string text = _formatter.GetText(rtfInput + @"\pageb", false);
         string[] lines = text.Split('\n');
         StringBuilder sb = new();
 

--- a/StoryBuilderLib/Services/Reports/PrintReports.cs
+++ b/StoryBuilderLib/Services/Reports/PrintReports.cs
@@ -20,6 +20,7 @@ public class PrintReports
     private StringReader fileStream;
     private Font printFont;
     private string documentText;
+    PrintDocument PrintDoc = new();
 
     //PrintHelper helper = new();
 
@@ -111,9 +112,13 @@ public class PrintReports
         float linesPerPage = ev.MarginBounds.Height / printFont.GetHeight(ev.Graphics);
 
         // Iterate over the file, printing each line.
-        while (count < linesPerPage &&
-               (line = fileStream.ReadLine()) != null)
+        while (count < linesPerPage && (line = fileStream.ReadLine()) != null)
         {
+            if (line == @"\PageBreak")
+            {
+                ev.HasMorePages = true;
+                break;
+            }
             float yPos = topMargin + count * printFont.GetHeight(ev.Graphics);
             ev.Graphics.DrawString(line, printFont, Brushes.Black, leftMargin, yPos, new StringFormat());
             count++;
@@ -131,15 +136,14 @@ public class PrintReports
         {
             fileStream = new StringReader(file);
             printFont = new Font("Arial", 12, FontStyle.Regular, GraphicsUnit.Pixel);
-            PrintDocument pd = new();
-            pd.PrintPage += new(pd_PrintPage);
+            PrintDoc.PrintPage += new(pd_PrintPage);
             Margins margins = new(100, 100, 100, 100);
-            pd.DefaultPageSettings.Margins = margins;
+            PrintDoc.DefaultPageSettings.Margins = margins;
             float pixelsPerChar = printFont.Size;
-            float lineWidth = pd.DefaultPageSettings.PrintableArea.Width;
+            float lineWidth = PrintDoc.DefaultPageSettings.PrintableArea.Width;
             int charsPerLine = Convert.ToInt32(lineWidth / pixelsPerChar);
             // Print the document.
-            pd.Print();
+            PrintDoc.Print();
         }
         catch (Exception ex)
         {
@@ -155,7 +159,7 @@ public class PrintReports
     /// <returns></returns>
     private string FormatText(string rtfInput, bool SummaryMode = false) 
     {
-        string text = _formatter.GetText(rtfInput + @"\pageb", false);
+        string text = _formatter.GetText(rtfInput, false);
         string[] lines = text.Split('\n');
         StringBuilder sb = new();
 
@@ -181,6 +185,7 @@ public class PrintReports
             sb.Replace("[", "\r\n[");
             sb.Replace("]", "]\r\n");
         }
+        sb.Append("\n\\PageBreak\n");
         return sb.ToString();
     }
 


### PR DESCRIPTION
When printing storybuilder makes many print requests and while this isnt an issue for printer users, people without one instead get a PDF file however instead of one single pdf of all the things the user wanted, a user will instead enter PDF Hell where each thing gets its own PDF.