### PR TITLE
Fix Releationship display issue

### DIFF
--- a/StoryBuilderLib/Controls/RelationshipView.xaml
+++ b/StoryBuilderLib/Controls/RelationshipView.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <editors:SfComboBox Grid.Row="0" Header="Relationship" PlaceholderText="Pick Relation" IsEditable="False" 
+        <ComboBox Grid.Row="0" Header="Relationship" PlaceholderText="Pick Relation" IsEditable="False" 
                             ItemsSource="{x:Bind CharVm.CharacterRelationships}"
                             SelectionChanged="RelationshipChanged"
                             DisplayMemberPath ="Partner.Name"

--- a/StoryBuilderLib/Controls/RelationshipView.xaml.cs
+++ b/StoryBuilderLib/Controls/RelationshipView.xaml.cs
@@ -20,11 +20,10 @@ public sealed partial class RelationshipView : UserControl
     /// CharacterRelationships is bound to is selected.
     /// However, one property need modified during LoadModel: the Partner  
     /// StoryElement in the RelationshipModel needs loaded from its Uuid.
-    public void RelationshipChanged(object sender, ComboBoxSelectionChangedEventArgs e)
+    private void RelationshipChanged(object sender, SelectionChangedEventArgs e)
     {
         CharVm.SaveRelationship(CharVm.CurrentRelationship);
         CharVm.LoadRelationship(CharVm.SelectedRelationship);
         CharVm.CurrentRelationship = CharVm.SelectedRelationship;
     }
-
 }


### PR DESCRIPTION
This fixes a bug where the relationship combobox would StoryBuilder.Models.RelationshipModel (or somthing along those lines) when a relationship is selected/