### PR TITLE
BugBash7

### DIFF
--- a/StoryBuilder/Views/Initialization.xaml
+++ b/StoryBuilder/Views/Initialization.xaml
@@ -27,11 +27,11 @@
                     <TextBox PlaceholderText="What is your name?" Margin="15" VerticalAlignment="Center" Text="{x:Bind _initVM.Name, Mode=TwoWay}"/>
                     <TextBox PlaceholderText="What is your email (optional)?" Margin="15" VerticalAlignment="Center"  Text="{x:Bind _initVM.Email, Mode=TwoWay}"/>
                     <StackPanel Orientation="Horizontal">
-                        <TextBox PlaceholderText="Where do you want to save your stories?" Name="ProjPath" Margin="15" VerticalAlignment="Center" Width="435" HorizontalAlignment="Left" Text="{x:Bind _initVM.Path, Mode=TwoWay}"/>
+                        <TextBox IsReadOnly="true" PlaceholderText="Where do you want to save your stories?" Name="ProjPath" Margin="15" VerticalAlignment="Center" Width="435" HorizontalAlignment="Left" Text="{x:Bind _initVM.Path, Mode=TwoWay}"/>
                         <Button Content="Browse" HorizontalAlignment="Center" Click="SetProjectPath"/>
                     </StackPanel>
                     <StackPanel Orientation="Horizontal">
-                        <TextBox PlaceholderText="Where do you want to backup your stories to?" Name="BackPath" Margin="15" VerticalAlignment="Center" Width="435" HorizontalAlignment="Left" Text="{x:Bind _initVM.BackupPath, Mode=TwoWay}"/>
+                        <TextBox IsReadOnly="True" PlaceholderText="Where do you want to backup your stories to?" Name="BackPath" Margin="15" VerticalAlignment="Center" Width="435" HorizontalAlignment="Left" Text="{x:Bind _initVM.BackupPath, Mode=TwoWay}"/>
                         <Button Content="Browse" HorizontalAlignment="Center" Click="SetBackupPath"/>
                     </StackPanel>
                 </StackPanel>

--- a/StoryBuilder/Views/Initialization.xaml.cs
+++ b/StoryBuilder/Views/Initialization.xaml.cs
@@ -13,8 +13,7 @@ using WinRT;
 namespace StoryBuilder.Views;
 
 /// <summary>
-/// This Page is displayed if Preferences.PreferencesInitialised
-/// is false.
+/// This Page is displayed if Preferences.Initialised is false.
 /// </summary>
 public sealed partial class PreferencesInitialization : Page
 {

--- a/StoryBuilder/Views/Shell.xaml
+++ b/StoryBuilder/Views/Shell.xaml
@@ -105,7 +105,7 @@
         <CommandBar  Background="{x:Bind ShellVm.UserPreferences.PrimaryColor}" IsOpen="False">
             <CommandBar.Content>
                 <StackPanel Orientation="Horizontal">
-                    <AutoSuggestBox PlaceholderText="Enter text to search for here" QueryIcon="Find" Width="285" Margin="0,8" QuerySubmitted="Search" TextChanged="ClearNodes" Text="{x:Bind ShellVm.FilterText, Mode=TwoWay}" VerticalAlignment="Center"/>
+                    <AutoSuggestBox PlaceholderText="Enter text to search for here" QueryIcon="Find" Width="335" Margin="0,8" QuerySubmitted="Search" TextChanged="ClearNodes" Text="{x:Bind ShellVm.FilterText, Mode=TwoWay}" VerticalAlignment="Center"/>
                 </StackPanel>
             </CommandBar.Content>
             <CommandBar.PrimaryCommands>

--- a/StoryBuilder/Views/Shell.xaml
+++ b/StoryBuilder/Views/Shell.xaml
@@ -85,7 +85,7 @@
                     <AppBarButton.Flyout>
                         <Flyout>
                             <StackPanel>
-                                <TextBlock Text="Are you sure you want to empty the trash?" HorizontalAlignment="Center"/>
+                                <TextBlock Text="Are you sure you want to empty the trash?" HorizontalAlignment="Center" Margin="0,0,0,10"/>
                                 <Button Command="{x:Bind ShellVm.EmptyTrashCommand, Mode=OneWay}" Content="Empty" HorizontalAlignment="Center"/>
                             </StackPanel>
                         </Flyout>
@@ -188,7 +188,11 @@
                                 </MenuFlyoutItem.KeyboardAccelerators>
                             </MenuFlyoutItem>
                             <MenuFlyoutSeparator/>
-                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.RemoveStoryElementVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveStoryElementCommand,Mode=OneWay}" Icon="Delete" Text="Delete story element"/>
+                            <MenuFlyoutItem Visibility="{x:Bind ShellVm.RemoveStoryElementVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveStoryElementCommand,Mode=OneWay}" Icon="Delete" Text="Delete story element">
+                                <MenuFlyoutItem.KeyboardAccelerators>
+                                    <KeyboardAccelerator Key="Delete"/>
+                                </MenuFlyoutItem.KeyboardAccelerators>
+                            </MenuFlyoutItem>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.RestoreStoryElementVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RestoreStoryElementCommand,Mode=OneWay}" Icon="Refresh" Text="Restore Story element"/>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.AddToNarrativeVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.AddToNarrativeCommand,Mode=OneWay}" Icon="Switch" Text="Add To Narrative"/>
                             <MenuFlyoutItem Visibility="{x:Bind ShellVm.RemoveFromNarrativeVisibility, Mode=TwoWay}" Command="{x:Bind ShellVm.RemoveFromNarrativeCommand,Mode=OneWay}" Icon="Switch" Text="Remove from Narrative"/>
@@ -204,16 +208,16 @@
                             <StackPanel  Orientation="Horizontal" >
                                 <Button ToolTipService.ToolTip="Move Left"
                                     FontFamily="Segoe MDL2 Assets" Content="&#xE09A;"
-                                    Command="{x:Bind ShellVm.MoveLeftCommand, Mode=OneWay}" />
+                                    Command="{x:Bind ShellVm.MoveLeftCommand, Mode=OneWay}"  Margin="5"/>
                                 <Button ToolTipService.ToolTip="Move Right"
                                         FontFamily="Segoe MDL2 Assets" Content="&#xE013;"
-                                        Command="{x:Bind ShellVm.MoveRightCommand, Mode=OneWay}" />
+                                        Command="{x:Bind ShellVm.MoveRightCommand, Mode=OneWay}"  Margin="5"/>
                                 <Button ToolTipService.ToolTip="Move Up"
                                         FontFamily="Segoe MDL2 Assets" Content="&#xE09C;"
-                                        Command="{x:Bind ShellVm.MoveUpCommand, Mode=OneWay}" />
+                                        Command="{x:Bind ShellVm.MoveUpCommand, Mode=OneWay}" Margin="5"/>
                                 <Button ToolTipService.ToolTip="Move Down"
                                         FontFamily="Segoe MDL2 Assets" Content="&#xE09D;"
-                                        Command="{x:Bind ShellVm.MoveDownCommand, Mode=OneWay}" />
+                                        Command="{x:Bind ShellVm.MoveDownCommand, Mode=OneWay}" Margin="5"/>
                             </StackPanel>
                         </Flyout>
                     </AppBarButton.Flyout>
@@ -273,7 +277,7 @@
                     <Grid.RowDefinitions>
                         <RowDefinition Height="*"/>
                     </Grid.RowDefinitions>
-                    <muxc:TreeView x:Name="NavigationTree" ContextFlyout="{StaticResource AddStoryElementFlyout}" ContextRequested="AddButton_ContextRequested"  ItemsSource="{x:Bind ShellVm.DataSource, Mode=TwoWay}" ItemInvoked="TreeViewItem_Invoked" >
+                    <muxc:TreeView x:Name="NavigationTree" AllowDrop="False" ContextFlyout="{StaticResource AddStoryElementFlyout}" ContextRequested="AddButton_ContextRequested"  ItemsSource="{x:Bind ShellVm.DataSource, Mode=TwoWay}" ItemInvoked="TreeViewItem_Invoked" >
                         <muxc:TreeView.ItemTemplate>
                             <DataTemplate  x:DataType="viewmodels:StoryNodeItem">
                                 <muxc:TreeViewItem ItemsSource="{x:Bind Children}" Background="{x:Bind Background, Mode=OneWay}" IsExpanded="{x:Bind IsExpanded, Mode=TwoWay}" RightTapped="TreeViewItem_RightTapped">

--- a/StoryBuilderLib/DAL/PreferencesIO.cs
+++ b/StoryBuilderLib/DAL/PreferencesIO.cs
@@ -88,7 +88,10 @@ public class PreferencesIO
                         break;
 
                     case "BackupOnOpen":
-                        _model.BackupOnOpen = tokens[1];
+                        if (tokens[1] == "True")
+                            _model.BackupOnOpen = true;
+                        else
+                            _model.BackupOnOpen = false;
                         break;
 
                     case "TimedBackup":
@@ -181,7 +184,7 @@ public class PreferencesIO
         NewPreferences.Add("LastTemplate=" + _model.LastSelectedTemplate);
 
         if (_model.WrapNodeNames == TextWrapping.WrapWholeWords) { NewPreferences.Add("WrapNodeNames=True"); }
-        else if (_model.WrapNodeNames == TextWrapping.NoWrap) { NewPreferences.Add("WrapNodeNames=False"); }
+        else { NewPreferences.Add("WrapNodeNames=False"); }
 
         await FileIO.WriteLinesAsync(preferencesFile, NewPreferences); //Writes file to disk.
     }

--- a/StoryBuilderLib/Models/Tools/PreferencesModel.cs
+++ b/StoryBuilderLib/Models/Tools/PreferencesModel.cs
@@ -40,7 +40,7 @@ public class PreferencesModel
     public bool QuoteOnStartup { get; set; }
 
     // Backup Information
-    public string BackupOnOpen { get; set; }
+    public bool BackupOnOpen { get; set; }
     public bool TimedBackup { get; set; }
     public int TimedBackupInterval { get; set; }
 

--- a/StoryBuilderLib/Services/Backup.cs
+++ b/StoryBuilderLib/Services/Backup.cs
@@ -1,16 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using Windows.Storage;
+using Windows.System;
 using CommunityToolkit.Mvvm.DependencyInjection;
+using Microsoft.UI.Xaml.Controls;
 using StoryBuilder.Models;
 using StoryBuilder.Services.Logging;
 using StoryBuilder.ViewModels;
+using DispatcherQueue = ABI.Windows.System.DispatcherQueue;
 
 namespace StoryBuilder.Services
 {
@@ -33,7 +33,7 @@ namespace StoryBuilder.Services
                 while (!timeBackupWorker.CancellationPending)
                 {
                     System.Threading.Thread.Sleep((GlobalData.Preferences.TimedBackupInterval * 60) * 1000);
-                    Log.Log(LogLevel.Trace, "Starting auto backup");
+                    Log.Log(LogLevel.Info, "Starting auto backup");
                     await BackupProject();
                 }
                 e.Cancel = true;
@@ -70,24 +70,31 @@ namespace StoryBuilder.Services
 
         public async Task BackupProject()
         {
-            Log.Log(LogLevel.Info, "Starting Project Backup");
-            //Creates backup directory if it doesnt exist
-            if (!Directory.Exists(GlobalData.Preferences.BackupDirectory)) { Directory.CreateDirectory(GlobalData.Preferences.BackupDirectory); }
-
+            Log.Log(LogLevel.Info, $"Starting Project Backup at {GlobalData.Preferences.BackupDirectory}");
             try
             {
+                //Creates backup directory if it doesn't exist
+                if (!Directory.Exists(GlobalData.Preferences.BackupDirectory))
+                {
+                    Log.Log(LogLevel.Info, "Backup dir not found, making it.");
+                    Directory.CreateDirectory(GlobalData.Preferences.BackupDirectory);
+                }
+
                 //Gets correct name for file
+                Log.Log(LogLevel.Info, "Getting backup path and file to made");
                 string fileName = $"{Shell.StoryModel.ProjectFile.Name} as of {DateTime.Now}".Replace('/', ' ').Replace(':', ' ').Replace(".stbx", "");
                 StorageFolder backupRoot = await StorageFolder.GetFolderFromPathAsync(GlobalData.Preferences.BackupDirectory.Replace(".stbx", ""));
                 StorageFolder backupLocation = await backupRoot.CreateFolderAsync(Shell.StoryModel.ProjectFile.Name, CreationCollisionOption.OpenIfExists);
                 Log.Log(LogLevel.Info, $"Backing up to {backupLocation.Path} as {fileName}.zip");
 
+                Log.Log(LogLevel.Info, "Writing file");
                 StorageFolder Temp = await StorageFolder.GetFolderFromPathAsync(GlobalData.RootDirectory);
                 Temp = await Temp.CreateFolderAsync("Temp", CreationCollisionOption.ReplaceExisting);
-                await Shell.StoryModel.ProjectFile.CopyAsync(Temp, Shell.StoryModel.ProjectFile.Name,NameCollisionOption.ReplaceExisting);
-                ZipFile.CreateFromDirectory(Temp.Path,Path.Combine(backupLocation.Path,fileName ) + ".zip");
-                
-                //Creates ziparchive then cleans up
+                await Shell.StoryModel.ProjectFile.CopyAsync(Temp, Shell.StoryModel.ProjectFile.Name,
+                    NameCollisionOption.ReplaceExisting);
+                ZipFile.CreateFromDirectory(Temp.Path, Path.Combine(backupLocation.Path, fileName) + ".zip");
+
+                //Creates zip archive then cleans up
                 Log.Log(LogLevel.Info, $"Created Zip file at {Path.Combine(backupLocation.Path, fileName)}.zip");
                 await Temp.DeleteAsync();
 
@@ -96,7 +103,17 @@ namespace StoryBuilder.Services
             }
             catch (Exception ex)
             {
-                Log.LogException(LogLevel.Error, ex, "Error backing up project");
+                Microsoft.UI.Dispatching.DispatcherQueue.GetForCurrentThread().TryEnqueue(() =>
+                {
+                    ContentDialog warning = new();
+                    warning.Title = "Backup Warning";
+                    warning.Content = "The last backup failed due to the following reason:\n" + ex.Message;
+                    warning.XamlRoot = GlobalData.XamlRoot;
+                    warning.CloseButtonText = "Understood.";
+                    warning.ShowAsync();
+                });
+
+                Log.LogException(LogLevel.Error, ex, $"Error backing up project {ex.Message}");
             }
             Log.Log(LogLevel.Info, "BackupProject complete");
         }

--- a/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml.cs
+++ b/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml.cs
@@ -45,7 +45,6 @@ public sealed partial class SaveAsDialog : Page
         ParentFolder = await folderPicker.PickSingleFolderAsync();
         SaveAsVm.ParentFolder = ParentFolder;
 
-        //TODO: Test for cancelled FolderPicker via 'if Parentfolder =! null {} else {}
         if (ParentFolder != null)
         {
             ProjectFolderPath = ParentFolder.Path;

--- a/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml.cs
+++ b/StoryBuilderLib/Services/Dialogs/SaveAsDialog.xaml.cs
@@ -4,19 +4,12 @@ using Microsoft.UI.Xaml.Controls;
 using StoryBuilder.Models;
 using StoryBuilder.ViewModels;
 using System;
-using System.IO;
 using System.Runtime.InteropServices;
 using Windows.Storage;
 using Windows.Storage.Pickers;
 
-// To learn more about WinUI, the WinUI project structure,
-// and more about our project templates, see: http://aka.ms/winui-project-info.
-
 namespace StoryBuilder.Services.Dialogs;
 
-/// <summary>
-/// An empty page that can be used on its own or navigated to within a Frame.
-/// </summary>
 public sealed partial class SaveAsDialog : Page
 {
     public SaveAsDialog()
@@ -53,11 +46,13 @@ public sealed partial class SaveAsDialog : Page
         SaveAsVm.ParentFolder = ParentFolder;
 
         //TODO: Test for cancelled FolderPicker via 'if Parentfolder =! null {} else {}
-            
-        ProjectFolderPath = ParentFolder.Path;
-        ProjectPathName.Text = ProjectFolderPath;
-        SaveAsVm.ProjectPathName = ProjectFolderPath;
-        ProjectPathName.IsReadOnly = true;
+        if (ParentFolder != null)
+        {
+            ProjectFolderPath = ParentFolder.Path;
+            ProjectPathName.Text = ProjectFolderPath;
+            SaveAsVm.ProjectPathName = ProjectFolderPath;
+            ProjectPathName.IsReadOnly = true;
+        }
     }
 
     [ComImport]

--- a/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -3,40 +3,52 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <ScrollViewer>
-        <StackPanel Width="400">
-            <Pivot>
-                <PivotItem Header="General">
-                    <StackPanel>
-                        <TextBox Header="Your name:" PlaceholderText="Put the name want to publish under here" HorizontalAlignment="Center" Margin="8" Width="300" Text="{x:Bind PreferencesVm.Name, Mode=TwoWay}"/>
-                        <TextBox Header="Your email:" PlaceholderText="Put your email here" Margin="8" Width="300" Text="{x:Bind PreferencesVm.Email, Mode=TwoWay}"/>
-                        <TextBox Header="Project directory:" PlaceholderText="Where do you want to store your stories?" Margin="8" Width="300" HorizontalAlignment="Center" Text="{x:Bind PreferencesVm.ProjectDir, Mode=TwoWay}"/>
+    <StackPanel Width="500">
+        <Pivot>
+            <PivotItem Header="General">
+                <StackPanel>
+                    <TextBox Header="Your name:" PlaceholderText="Put the name want to publish under here" HorizontalAlignment="Center" Margin="8" Width="300" Text="{x:Bind PreferencesVm.Name, Mode=TwoWay}"/>
+                    <TextBox Header="Your email:" PlaceholderText="Put your email here" Margin="8" Width="300" Text="{x:Bind PreferencesVm.Email, Mode=TwoWay}"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <TextBox IsReadOnly="True" Name="ProjDirBox" Header="Project directory:" PlaceholderText="Where do you want to store your stories?" Margin="8" Width="300" VerticalAlignment="Center" Text="{x:Bind PreferencesVm.ProjectDir, Mode=OneWay}"/>
+                        <Button Content="Browse" Click="SetProjectPath" VerticalAlignment="Center" Margin="0,25,10,0"/>
                     </StackPanel>
-                </PivotItem>
-                <PivotItem Header="Backup">
-                    <StackPanel>
-                        <CheckBox Content="Make timed backups" Margin="8" HorizontalAlignment="Center" Name="TimedBackups" IsChecked="{x:Bind PreferencesVm.Backup, Mode=TwoWay}"/>
-                        <NumberBox Header="How often should backups be made? (Minutes)" Margin="4" Width="300" HorizontalAlignment="Center" Value="{x:Bind PreferencesVm.BackupInterval, Mode=TwoWay}"/>
-                        <TextBox Header="Backup directory:" PlaceholderText="Where do you want to store your backups?" Margin="8" Width="300" HorizontalAlignment="Center" Text="{x:Bind PreferencesVm.BackupDir, Mode=TwoWay}"/>
+                </StackPanel>
+            </PivotItem>
+            <PivotItem Header="Backup">
+                <StackPanel>
+                    <CheckBox Content="Make a backup of the story when opened" Margin="4" HorizontalAlignment="Center" Name="BackupOnOpen" IsChecked="{x:Bind PreferencesVm.BackupUpOnOpen, Mode=TwoWay}"/>
+                    <CheckBox Content="Make timed backups" Margin="8" HorizontalAlignment="Center" Name="TimedBackups" IsChecked="{x:Bind PreferencesVm.Backup, Mode=TwoWay}"/>
+                    <NumberBox Header="How often should backups be made? (Minutes)" Maximum="300" Minimum="1" Margin="4" Width="300" HorizontalAlignment="Center" Value="{x:Bind PreferencesVm.BackupInterval, Mode=TwoWay}"/>
+                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Right">
+                        <TextBox Header="Backup directory:" PlaceholderText="Where do you want to store your backups?" IsReadOnly="True" Margin="8" Width="300" HorizontalAlignment="Center" Text="{x:Bind PreferencesVm.BackupDir, Mode=TwoWay}"/>
+                        <Button Content="Browse" Click="SetBackupPath" VerticalAlignment="Center" Margin="0,25,10,0"/>
                     </StackPanel>
-               </PivotItem>
-                <PivotItem Header="Other">
-                    <StackPanel>
-                        <CheckBox Content="Send error logs to Team StoryBuilder" Margin="8" HorizontalAlignment="Center" IsChecked="{x:Bind PreferencesVm.ErrorConsent, Mode=TwoWay}"/>
-                        <CheckBox Content="Send me newsletters about StoryBuilder" Margin="8" HorizontalAlignment="Center" IsChecked="{x:Bind PreferencesVm.NewsConsent, Mode=TwoWay}"/>
-                        <CheckBox Content="Wrap node names" Margin="8" HorizontalAlignment="Center" IsChecked="{x:Bind PreferencesVm.WrapNodeNames, Mode=TwoWay}"/>
-                        <TextBlock Text="Changing these settings may require a restart to take effect." HorizontalAlignment="Center" VerticalAlignment="Bottom"/>
-                    </StackPanel>
-                </PivotItem>
-                <PivotItem Header="About">
-                    <StackPanel>
-                        <TextBlock Name="Version" HorizontalAlignment="Center" Margin="5"/>
-                        <Button Content="Open Logs folder" HorizontalAlignment="Center" Click="OpenPath" Margin="5"/>
-                        <Button Content="Join the StoryBuilder Discord!" HorizontalAlignment="Center" Click="OpenDiscordURL" Margin="5"/>
-                        <TextBlock Text="StoryBuilder was created by Terry Cox, Jake Shaw (Rarisma) and Kyle Lemons" TextWrapping="WrapWholeWords" Margin="5" FontSize="13"/>
-                    </StackPanel>
-                </PivotItem>
-            </Pivot>
-        </StackPanel>
-    </ScrollViewer>
+                </StackPanel>
+            </PivotItem>
+            <PivotItem Header="Other">
+                <StackPanel>
+                    <CheckBox Content="Send error logs to Team StoryBuilder" Margin="8" HorizontalAlignment="Center" IsChecked="{x:Bind PreferencesVm.ErrorConsent, Mode=TwoWay}"/>
+                    <CheckBox Content="Send me newsletters about StoryBuilder" Margin="8" HorizontalAlignment="Center" IsChecked="{x:Bind PreferencesVm.NewsConsent, Mode=TwoWay}"/>
+                    <CheckBox Content="Wrap node names" Margin="8" HorizontalAlignment="Center" IsChecked="{x:Bind PreferencesVm.WrapNodeNames, Mode=TwoWay}"/>
+                </StackPanel>
+            </PivotItem>
+            <PivotItem Header="About">
+                <StackPanel>
+                    <TextBlock Name="Version" HorizontalAlignment="Center" Margin="5"/>
+                    <Button Content="Open Logs folder" HorizontalAlignment="Center" Click="OpenPath" Margin="5"/>
+                    <Button Content="Join the StoryBuilder Discord!" HorizontalAlignment="Center" Click="OpenDiscordURL" Margin="5"/>
+                    <TextBlock Text="StoryBuilder was created by Terry Cox, Jake Shaw (Rarisma) and Kyle Lemons" TextWrapping="WrapWholeWords" Margin="5" FontSize="13"/>
+                </StackPanel>
+            </PivotItem>
+            <PivotItem Opacity="0" IsEnabled="False" Header="" Name="Dev">
+                <StackPanel>
+                    <Button Content="Show init page on reload"/>
+                    <Button Content="Crash"/>
+                    <TextBlock Name="cpuarch"/>
+                </StackPanel>
+            </PivotItem>
+        </Pivot>
+        <TextBlock Text="Changing these settings may require a restart to take effect." HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,15,0,0"/>
+    </StackPanel>
 </Page>

--- a/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
+++ b/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
@@ -1,9 +1,15 @@
-﻿using System.Diagnostics;
+﻿using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Threading;
+using Windows.Storage;
+using Windows.Storage.Pickers;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using StoryBuilder.Models;
 using StoryBuilder.ViewModels.Tools;
+using WinRT;
 
 namespace StoryBuilder.Services.Dialogs.Tools;
 
@@ -33,4 +39,64 @@ public sealed partial class PreferencesDialog : Page
         Browser.StartInfo.UseShellExecute = true;
         Browser.Start();
     }
+
+    private async void SetBackupPath(object sender, RoutedEventArgs e)
+    {
+        FolderPicker folderPicker = new();
+        if (Window.Current == null)
+        {
+            //IntPtr hwnd = GetActiveWindow();
+            IntPtr hwnd = GlobalData.WindowHandle;
+            IInitializeWithWindow initializeWithWindow = folderPicker.As<IInitializeWithWindow>();
+            initializeWithWindow.Initialize(hwnd);
+        }
+
+        folderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        folderPicker.FileTypeFilter.Add("*");
+        StorageFolder folder = await folderPicker.PickSingleFolderAsync();
+        if (folder != null)
+        {
+            Ioc.Default.GetRequiredService<PreferencesViewModel>().BackupDir = folder.Path;
+        }
+    }
+    private async void SetProjectPath(object sender, RoutedEventArgs e)
+    {
+        FolderPicker folderPicker = new();
+        if (Window.Current == null)
+        {
+            //IntPtr hwnd = GetActiveWindow();
+            IntPtr hwnd = GlobalData.WindowHandle;
+            IInitializeWithWindow initializeWithWindow = folderPicker.As<IInitializeWithWindow>();
+            initializeWithWindow.Initialize(hwnd);
+        }
+
+        folderPicker.SuggestedStartLocation = PickerLocationId.DocumentsLibrary;
+        folderPicker.FileTypeFilter.Add("*");
+        StorageFolder folder = await folderPicker.PickSingleFolderAsync();
+        if (folder != null)
+        {
+            Ioc.Default.GetRequiredService<PreferencesViewModel>().ProjectDir = folder.Path;
+            ProjDirBox.Text = folder.Path; //Updates the box visually (fixes visual glitch.)
+        }
+    }
+
+    [ComImport]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    [Guid("EECDBF0E-BAE9-4CB6-A68E-9598E1CB57BB")]
+    internal interface IWindowNative
+    {
+        IntPtr WindowHandle { get; }
+    }
+
+    [ComImport]
+    [Guid("3E68D4BD-7135-4D10-8018-9FB6D9F33FA1")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    public interface IInitializeWithWindow
+    {
+        void Initialize(IntPtr hwnd);
+    }
+
+    [DllImport("user32.dll", ExactSpelling = true, CharSet = CharSet.Auto, PreserveSig = true, SetLastError = false)]
+    public static extern IntPtr GetActiveWindow();
+
 }

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -471,7 +471,7 @@ namespace StoryBuilder.ViewModels
 
                 // Save the new project
                 await SaveFile();
-                await MakeBackup();
+                if (GlobalData.Preferences.BackupOnOpen) { await MakeBackup(); }
                 Ioc.Default.GetService<BackupService>().StartTimedBackup();
                 Messenger.Send(new StatusChangedMessage(new($"New project command executing", LogLevel.Info, true)));
 
@@ -671,15 +671,18 @@ namespace StoryBuilder.ViewModels
 
                 StoryReader rdr = Ioc.Default.GetService<StoryReader>();
                 StoryModel = await rdr.ReadFile(StoryModel.ProjectFile);
-                await Ioc.Default.GetService<BackupService>().BackupProject();
+
+                if (GlobalData.Preferences.BackupOnOpen) { await Ioc.Default.GetService<BackupService>().BackupProject(); }
+               
                 if (StoryModel.ExplorerView.Count > 0)
                 {
                     SetCurrentView(StoryViewType.ExplorerView);
-                    Messenger.Send(new StatusChangedMessage(new($"Open Story completed", LogLevel.Info )));
+                    Messenger.Send(new StatusChangedMessage(new($"Open Story completed", LogLevel.Info)));
                 }
                 GlobalData.MainWindow.Title = $"StoryBuilder - Editing {StoryModel.ProjectFilename.Replace(".stbx", "")}";
-                new UnifiedVM().UpdateRecents(Path.Combine(StoryModel.ProjectFolder.Path,StoryModel.ProjectFile.Name));
-                Ioc.Default.GetService<BackupService>().StartTimedBackup();
+                new UnifiedVM().UpdateRecents(Path.Combine(StoryModel.ProjectFolder.Path,StoryModel.ProjectFile.Name)); 
+                if (GlobalData.Preferences.TimedBackup) { Ioc.Default.GetService<BackupService>().StartTimedBackup(); }
+                
 
                 TreeViewNodeClicked(DataSource[0]); // Navigate to the tree root
                 string msg = $"Opened project {StoryModel.ProjectFilename}";

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.DependencyInjection;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
@@ -348,10 +349,18 @@ namespace StoryBuilder.ViewModels
 
         #endregion
 
-            #region Public Methods
+        #region Public Methods
 
         public async Task PrintCurrentNodeAsync()
         {
+            if (RightTappedNode == null)
+            {
+                Messenger.Send(new StatusChangedMessage(new($"Right tap a node to print", LogLevel.Warn)));
+                Logger.Log(LogLevel.Info, "Print node failed as no node is selected");
+                _canExecuteCommands = true;
+                return;
+            }
+
             PrintReportDialogVM PrintVM = Ioc.Default.GetRequiredService<PrintReportDialogVM>();
             PrintVM.SelectedNodes.Clear();
             PrintVM.SelectedNodes.Add(RightTappedNode);
@@ -698,7 +707,14 @@ namespace StoryBuilder.ViewModels
             _canExecuteCommands = true;
         }
         public async Task SaveFile()
-        { 
+        {
+            if (DataSource.Count == 0 || DataSource == null)
+            {
+                Messenger.Send(new StatusChangedMessage(new($"You need to open a story first!", LogLevel.Info,false)));
+                Logger.Log(LogLevel.Info, "SaveFile command cancelled (DataSource was null or empty)");
+                return;
+            }
+            
             Logger.Log(LogLevel.Trace, "Saving file");
             try //Updating the lost modified timer
             {
@@ -843,22 +859,32 @@ namespace StoryBuilder.ViewModels
 
         private async void CloseFile()
         {
-            //BUG: Close file logic doesn't work (see comments)
             _canExecuteCommands = false;
             Messenger.Send(new StatusChangedMessage(new($"Closing project", LogLevel.Info, true)));
-            // Save the existing file if changed
+
             if (StoryModel.Changed)
             {
-                SaveModel();
-                await WriteModel();
+                ContentDialog Warning = new()
+                {
+                    Title = "Save changes?",
+                    PrimaryButtonText = "Yes",
+                    SecondaryButtonText = "No",
+                    XamlRoot = GlobalData.XamlRoot
+                };
+                if (await Warning.ShowAsync() == ContentDialogResult.Primary)
+                {
+                    SaveModel();
+                    await WriteModel();
+                }
             }
+
             ResetModel();
+            RightTappedNode = null; //Null right tapped node to prevent possible issues.
             SetCurrentView(StoryViewType.ExplorerView);
             GlobalData.MainWindow.Title = "StoryBuilder";
             Ioc.Default.GetService<BackupService>().StopTimedBackup();
             DataSource = StoryModel.ExplorerView;
             ShowHomePage();
-            //TODO: Navigate to background Page (is there one?)
             Messenger.Send(new StatusChangedMessage(new($"Close story command completed", LogLevel.Info, true)));
             _canExecuteCommands = true;
         }
@@ -874,11 +900,20 @@ namespace StoryBuilder.ViewModels
             _canExecuteCommands = false;
             Messenger.Send(new StatusChangedMessage(new($"Executing Exit project command", LogLevel.Info, true)));
 
-            //TODO: Only close if changed
             if (StoryModel.Changed)
             {
-                SaveModel();
-                await WriteModel();
+                ContentDialog Warning = new()
+                {
+                    Title = "Save changes?",
+                    PrimaryButtonText = "Yes",
+                    SecondaryButtonText = "No",
+                    XamlRoot = GlobalData.XamlRoot
+                };
+                if (await Warning.ShowAsync() == ContentDialogResult.Primary)
+                {
+                    SaveModel();
+                    await WriteModel();
+                }
             }
             Logger.Flush();
             Application.Current.Exit();  // Win32
@@ -1624,6 +1659,13 @@ namespace StoryBuilder.ViewModels
                 Messenger.Send(new StatusChangedMessage(new("You can only restore from Deleted StoryElements", LogLevel.Warn)));
                 return;
             }
+
+            if (RightTappedNode.IsRoot)
+            {
+                Messenger.Send(new StatusChangedMessage(new("You can't restore a root node!", LogLevel.Warn)));
+                return;
+            }
+            
             //TODO: Add dialog to confirm restore
             ObservableCollection<StoryNodeItem> target = DataSource[0].Children;
             DataSource[1].Children.Remove(RightTappedNode);
@@ -1662,7 +1704,15 @@ namespace StoryBuilder.ViewModels
         /// </summary>
         private void EmptyTrash()
         {
+            if (DataSource == null)
+            {
+                Messenger.Send(new StatusChangedMessage(new($"You need to load a story first!", LogLevel.Warn, false)));
+                Logger.Log(LogLevel.Info, "Failed to empty trash as DataSource is null. (Is a story loaded?)");
+                return;
+            }
+            
             StatusMessage = "Trash Emptied.";
+            Logger.Log(LogLevel.Info,"Emptied Trash.");
             DataSource[1].Children.Clear();
         }
 
@@ -1732,6 +1782,12 @@ namespace StoryBuilder.ViewModels
 
         public void ViewChanged()
         {
+            if (DataSource == null || DataSource.Count == 0)
+            {
+                Messenger.Send(new StatusChangedMessage(new($"You need to load a story first!", LogLevel.Warn, false)));
+                Logger.Log(LogLevel.Info, "Failed to switch views as DataSource is null or empty. (Is a story loaded?)");
+                return;
+            }
             if (!SelectedView.Equals(CurrentView))
             {
                 CurrentView = SelectedView;

--- a/StoryBuilderLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryBuilderLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -11,6 +11,7 @@ namespace StoryBuilder.ViewModels.Tools;
 
 public class PreferencesViewModel : ObservableRecipient
 {
+    public bool init = true;
     private string _backupdir;
     public string BackupDir
     {
@@ -68,6 +69,13 @@ public class PreferencesViewModel : ObservableRecipient
         set => _wrapNodeNames = value;
     }
 
+    private bool _backupOnOpen;
+    public bool BackupUpOnOpen
+    {
+        get => _backupOnOpen;
+        set => _backupOnOpen = value;
+    }
+
     /// <summary>
     /// Saves the users preferences to disk.
     /// </summary>
@@ -85,6 +93,8 @@ public class PreferencesViewModel : ObservableRecipient
         prf.TimedBackupInterval = BackupInterval;
         prf.TimedBackup = Backup;
         prf.Newsletter = NewsConsent;
+        prf.PreferencesInitialised = init;
+        prf.BackupOnOpen = BackupUpOnOpen;
 
         if (WrapNodeNames) {prf.WrapNodeNames = TextWrapping.WrapWholeWords;}
         else {prf.WrapNodeNames = TextWrapping.NoWrap;}
@@ -109,6 +119,8 @@ public class PreferencesViewModel : ObservableRecipient
         Backup = _model.TimedBackup;
         NewsConsent = _model.Newsletter;
         BackupDir = _model.BackupDirectory;
+        BackupUpOnOpen = _model.BackupOnOpen;
+
 
         if (_model.WrapNodeNames == TextWrapping.WrapWholeWords) {WrapNodeNames = true;}
         else {WrapNodeNames = false; }


### PR DESCRIPTION
This PR does the following:
- Removes ability for user to manually type paths (fixes  #299 )
- Limits the backup timer to between 1 and 300 minutes (fixes #300 )
- Adds a bit of margin to the empty trash confirmation to make it look prettier
- Increases Search Bar width to take up the now empty space from #287 
- Add Delete as a keyboard accellerator for delete nodes
- Adds a bit of margin around the move arrows.
- Removes drag and drop of tree nodes in favor of the move arrows
- Impliments backup on open setting
- Adds stubbed debug menu
- Fix issue that caused node wrapping setting to not be respected
- Updated backup logging and fixed crash
- Fixed crash caused by user clicking cancel on save as dialog
- Fixed crash caused by trying to print a node with nothing right clicked
- Fixed crash caused by trying to save with nothing open
- Added save prompt if story has unsaved changes when closing story to using the exit option,
- Right tapped node is now nulled when story is closed to prevent unforseen possibilities. (Fixes #303)
- Fixed this monstrosity (Fixes #302)
![image](https://user-images.githubusercontent.com/49795711/168399231-ead1fa2b-6ce2-468a-83e3-8069dbe63e9e.png)

- Fixed crash caused by emptying trash without a story loaded
- Fixed crash caused by changing view with nothing loaded