### PR TITLE
Final Bug Bash

### DIFF
--- a/StoryBuilder/Views/Shell.xaml
+++ b/StoryBuilder/Views/Shell.xaml
@@ -318,7 +318,7 @@
                       SelectedItem="{x:Bind ShellVm.SelectedView, Mode=TwoWay}" />
             <TextBlock Text="{x:Bind ShellVm.StatusMessage, Mode=OneWay}"
                        Foreground="{x:Bind ShellVm.StatusColor, Mode=OneWay}"
-                       Width = "300"
+                       Width = "350"
                        FontSize="14"
                        Margin="10"
                        FontFamily="Segoe UI" Padding="0,5"/>

--- a/StoryBuilderLib/Controls/CharacterName.cs
+++ b/StoryBuilderLib/Controls/CharacterName.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.UI.Xaml.Controls;
+﻿using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
 using StoryBuilder.Models;
 using StoryBuilder.ViewModels;
 
@@ -10,8 +11,12 @@ public sealed class CharacterName : ComboBox
     public CharacterName() : base()
     {
         DefaultStyleKey = typeof(ComboBox);
+        Loaded += CharacterName_Loaded;
+    }
+
+    private void CharacterName_Loaded(object o, RoutedEventArgs routedEventArgs)
+    {
         StoryModel model = ShellViewModel.GetModel();
         ItemsSource = model.StoryElements.Characters;
- 
     }
 }

--- a/StoryBuilderLib/Controls/CharacterName.cs
+++ b/StoryBuilderLib/Controls/CharacterName.cs
@@ -11,7 +11,7 @@ public sealed class CharacterName : ComboBox
     public CharacterName() : base()
     {
         DefaultStyleKey = typeof(ComboBox);
-        Loaded += CharacterName_Loaded;
+        Loaded += CharacterName_Loaded; 
     }
 
     private void CharacterName_Loaded(object o, RoutedEventArgs routedEventArgs)

--- a/StoryBuilderLib/Controls/ProblemName.cs
+++ b/StoryBuilderLib/Controls/ProblemName.cs
@@ -10,7 +10,12 @@ public sealed class ProblemName : ComboBox
     public ProblemName() : base()
     {
         DefaultStyleKey = typeof(ComboBox);
-        StoryModel model = ShellViewModel.GetModel();   
+        Loaded += ProblemName_Loaded;
+    }
+
+    private void ProblemName_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        StoryModel model = ShellViewModel.GetModel();
         ItemsSource = model.StoryElements.Problems;
     }
 }

--- a/StoryBuilderLib/Controls/SettingName.cs
+++ b/StoryBuilderLib/Controls/SettingName.cs
@@ -10,6 +10,11 @@ public sealed class SettingName : ComboBox
     public SettingName() : base()
     {
         DefaultStyleKey = typeof(ComboBox);
+        Loaded += SettingName_Loaded;
+    }
+
+    private void SettingName_Loaded(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
         StoryModel model = ShellViewModel.GetModel();
         ItemsSource = model.StoryElements.Settings;
     }

--- a/StoryBuilderLib/Services/Dialogs/NewRelationshipPage.xaml.cs
+++ b/StoryBuilderLib/Services/Dialogs/NewRelationshipPage.xaml.cs
@@ -2,8 +2,12 @@
 using System;
 using System.Runtime.InteropServices;
 using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.DependencyInjection;
+using NLog;
 using StoryBuilder.Models;
+using StoryBuilder.Services.Logging;
 using StoryBuilder.ViewModels;
+using LogLevel = StoryBuilder.Services.Logging.LogLevel;
 
 namespace StoryBuilder.Services.Dialogs;
 

--- a/StoryBuilderLib/ViewModels/CharacterViewModel.cs
+++ b/StoryBuilderLib/ViewModels/CharacterViewModel.cs
@@ -805,6 +805,13 @@ public class CharacterViewModel : ObservableRecipient, INavigable
         NextCharacter: continue;
         }
 
+        if (VM.ProspectivePartners.Count == 0)
+        {
+            Ioc.Default.GetRequiredService<LogService>().Log(LogLevel.Warn,"There are no prospective partners, not showing AddRelationship Dialog." );
+            Ioc.Default.GetRequiredService<ShellViewModel>().ShowMessage(LogLevel.Warn, "This character already has a relationship with everyone",false);
+            return;
+        }
+
         //Creates dialog and shows dialog
         ContentDialog NewRelationship = new();
         NewRelationship.Title = "New relationship";

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -24,6 +24,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
+using System.Threading;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.Pickers;
@@ -630,7 +631,6 @@ namespace StoryBuilder.ViewModels
         /// If fromPath is specified then the picker is skipped.
         /// </summary>
         /// <param name="fromPath"></param>
-        /// <returns></returns>
         public async Task OpenFile(string fromPath = "")
         {
             if (StoryModel.Changed)
@@ -675,6 +675,7 @@ namespace StoryBuilder.ViewModels
                     _canExecuteCommands = true;  // unblock other commands
                     return;
                 }
+
                 Ioc.Default.GetService<BackupService>().StopTimedBackup();
                 //NOTE: BasicProperties.DateModified can be the date last changed
 
@@ -691,9 +692,9 @@ namespace StoryBuilder.ViewModels
                 GlobalData.MainWindow.Title = $"StoryBuilder - Editing {StoryModel.ProjectFilename.Replace(".stbx", "")}";
                 new UnifiedVM().UpdateRecents(Path.Combine(StoryModel.ProjectFolder.Path,StoryModel.ProjectFile.Name)); 
                 if (GlobalData.Preferences.TimedBackup) { Ioc.Default.GetService<BackupService>().StartTimedBackup(); }
-                
 
                 //TreeViewNodeClicked(DataSource[0]); // Navigate to the tree root
+                ShowHomePage();
                 string msg = $"Opened project {StoryModel.ProjectFilename}";
                 Logger.Log(LogLevel.Info, msg);
             }

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -645,7 +645,7 @@ namespace StoryBuilder.ViewModels
             try
             {
                 ResetModel();
-
+                ShowHomePage();
                 if (fromPath == "" || !File.Exists(fromPath))
                 {
                     //var window = new Window();
@@ -693,7 +693,7 @@ namespace StoryBuilder.ViewModels
                 if (GlobalData.Preferences.TimedBackup) { Ioc.Default.GetService<BackupService>().StartTimedBackup(); }
                 
 
-                TreeViewNodeClicked(DataSource[0]); // Navigate to the tree root
+                //TreeViewNodeClicked(DataSource[0]); // Navigate to the tree root
                 string msg = $"Opened project {StoryModel.ProjectFilename}";
                 Logger.Log(LogLevel.Info, msg);
             }

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -1279,7 +1279,8 @@ namespace StoryBuilder.ViewModels
                 if (_targetIndex == -1) { _targetCollection.Add(CurrentNode); }
                 else { _targetCollection.Insert(_targetIndex, CurrentNode); }
                 CurrentNode.Parent = targetParent;
-                Logger.Log(LogLevel.Info, $"Moving {CurrentNode.Name} left from parent {CurrentNode.Parent.Name} to parent {CurrentNode.Parent.Parent.Name}");
+
+                Logger.Log(LogLevel.Info, $"Moving {CurrentNode.Name} left to parent {CurrentNode.Parent.Name}");
             }
             else
             {


### PR DESCRIPTION
This final bug bash fixes the following:

- An error moving left causes a crash
- Fixed #337 with CharacterName, ProblemName and SceneName controls not updating when the story is changed
- Fixed a possible exception/crash when cancing the file open menu when a story file isn't found
- User is now prevented from opening the new relationship dialog if there are no prospective partner. (Fixed #339)

There are two notes:
- The length of status message has been increased from 300 to 350, to allow slightly longer status messages.
- When a story is opened, the overview node is no longer automatically selected.