### PR TITLE
Comment out actual logging to Parse Server, but keep the remaining code

### DIFF
--- a/StoryBuilderLib/Services/Parse/ParseService.cs
+++ b/StoryBuilderLib/Services/Parse/ParseService.cs
@@ -62,6 +62,7 @@ namespace StoryBuilder.Services.Parse
         private LogService log = Ioc.Default.GetService<LogService>();
         public async Task PostPreferences(PreferencesModel preferences)
         {
+            return;
             log.Log(LogLevel.Info, "Posting preferences data to parse");
             try
             {
@@ -120,6 +121,7 @@ namespace StoryBuilder.Services.Parse
 
         public async Task PostVersion()
         {
+            return;
             log.Log(LogLevel.Info, "Posting version data to parse");
             var preferences = GlobalData.Preferences;
             try


### PR DESCRIPTION
Both Preferences and Version records are generated when changes occur. We want the data,
and the code contains the structure of when to call and what to do to log these changes.
But we're scrapping the Parse Server back-end stack and replacing it with a MySql database.
We'll replace this code with database calls soon.