### PR TITLE
Correct failure to track _changed (dirty bit)  for ScenePurpose. The …

### DIFF
--- a/StoryBuilder/Views/ScenePage.xaml.cs
+++ b/StoryBuilder/Views/ScenePage.xaml.cs
@@ -1,6 +1,5 @@
 ﻿using CommunityToolkit.Mvvm.DependencyInjection;
 using StoryBuilder.ViewModels;
-using System.Collections.ObjectModel;
 
 namespace StoryBuilder.Views;
 

--- a/StoryBuilderLib/ViewModels/SceneViewModel.cs
+++ b/StoryBuilderLib/ViewModels/SceneViewModel.cs
@@ -358,7 +358,7 @@ public class SceneViewModel : ObservableRecipient, INavigable
         foreach (string purpose in Model.ScenePurpose)
         {
             AddScenePurpose(purpose);
-            ScenePurpose.Add(purpose);
+            //ScenePurpose.Add(purpose);
         }
 
         ValueExchange = Model.ValueExchange;

--- a/StoryBuilderLib/ViewModels/SceneViewModel.cs
+++ b/StoryBuilderLib/ViewModels/SceneViewModel.cs
@@ -439,12 +439,20 @@ public class SceneViewModel : ObservableRecipient, INavigable
     public ClearScenePurposeDelegate ClearScenePurpose;
     public AddScenePurposeDelegate AddScenePurpose;
 
+    /// <summary>
+    /// This method is called by the ScenePage.xaml.cs file when the ScenePurpose changes.
+    /// Besides updating the ViewModel's list of purposes, it also Calls SceneVm's
+    /// OnPropertyChanged to set the changed (dirty) flag if appropriate
+    /// </summary>
+    /// <param name="sender"></param>
+    /// <param name="e"></param>
     public void ScenePurpose_SelectionChanged(object sender, ComboBoxSelectionChangedEventArgs e)
     {
         foreach (string purpose in e.AddedItems)
             ScenePurpose.Add(purpose);
         foreach (string purpose in e.RemovedItems)
             ScenePurpose.Remove(purpose);
+        OnPropertyChanged(ScenePurpose, new PropertyChangedEventArgs("ScenePurpose"));
     }
 
     private bool CastMemberExists(string uuid)


### PR DESCRIPTION
…conflrols is a SfComboBox with SelectMode=Multiple;

it uses SelectionChanged event from code-behind. Added a call to OnPrpertyChanged from that event.

Per issue #389