### PR TITLE
Implement Single Instancing

### DIFF
--- a/StoryBuilder/App.xaml.cs
+++ b/StoryBuilder/App.xaml.cs
@@ -8,8 +8,10 @@
   using dotenv.net;
   using dotenv.net.Utilities;
   using Microsoft.Extensions.DependencyInjection;
+  using Microsoft.UI.Dispatching;
   using Microsoft.UI.Xaml;
   using Microsoft.UI.Xaml.Controls;
+  using Microsoft.Windows.AppLifecycle;
   using PInvoke;
   using StoryBuilder.DAL;
   using StoryBuilder.Models;
@@ -27,6 +29,7 @@
   using StoryBuilder.Views;
   using Syncfusion.Licensing;
   using WinUIEx;
+  using AppInstance = Microsoft.Windows.AppLifecycle.AppInstance;
   using UnhandledExceptionEventArgs = Microsoft.UI.Xaml.UnhandledExceptionEventArgs;
 
   namespace StoryBuilder;
@@ -53,12 +56,14 @@ public partial class App : Application
     /// </summary>
     public App()
     {
+        CheckForOtherInstances(); //Check other instances aren't already open.
+        
         ConfigureIoc();
 
         GlobalData.Version = "Version: " + Package.Current.Id.Version.Major + "." + Package.Current.Id.Version.Minor + "." + Package.Current.Id.Version.Build + "." + Package.Current.Id.Version.Revision;
 
-        var path = Path.Combine(Package.Current.InstalledLocation.Path, ".env");
-        var options = new DotEnvOptions(false, new[] { path });
+        string path = Path.Combine(Package.Current.InstalledLocation.Path, ".env");
+        DotEnvOptions options = new(false, new[] { path });
         try
         {
             DotEnv.Load(options);
@@ -73,6 +78,36 @@ public partial class App : Application
 
         _log = Ioc.Default.GetService<LogService>();
         Current.UnhandledException += OnUnhandledException;
+    }
+
+    /// <summary>
+    /// This checks for other already open storybuilder instances
+    /// If one is open, pull it up and kill this instance.
+    /// </summary>
+    private async void CheckForOtherInstances()
+    {
+        //If this instance is the first, then we will register it, otherwise we will get info about the other instance.
+        AppInstance _MainInstance = AppInstance.FindOrRegisterForKey("main"); //Get main instance
+        _MainInstance.Activated += ActivateMainInstance;
+
+        //Redirect to other instance if one exists, otherwise continue initializing this instance.
+        if (!_MainInstance.IsCurrent)
+        {
+            //Bring up the 'main' instance 
+            AppActivationArguments _ActivatedEventArgs = AppInstance.GetCurrent().GetActivatedEventArgs();
+            await _MainInstance.RedirectActivationToAsync(_ActivatedEventArgs);
+            Process.GetCurrentProcess().Kill();
+        }
+    }
+
+    /// <summary>
+    /// When a second instance is opened, this code will be ran on the main (first) instance
+    /// It will bring up the main window.
+    /// </summary>
+    private void ActivateMainInstance(object sender, AppActivationArguments e)
+    {
+        GlobalData.MainWindow.Restore(); //Resize window and unminimize window
+        GlobalData.MainWindow.BringToFront(); //Bring window to front
     }
 
     private static void ConfigureIoc()

--- a/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -50,23 +50,26 @@
                     <TextBlock Name="Changelog" TextWrapping="Wrap"/>
                 </ScrollViewer>
             </PivotItem>
-            <PivotItem Opacity="0" IsEnabled="False" Header="" Name="Dev">
-                <StackPanel HorizontalAlignment="Center">
-                    <StackPanel Orientation="Horizontal">
-                        <Button Content="Set Init to false" Click="SetInitToFalse"/>
-                        <Button Content="Throw exception" Click="ThrowException" Margin="10,0"/>
-                        <Button Content="Attach Elmah" Click="AttachElmah"/>
-                        <Button Content="Run InstallService" Click="Reinstall"/>
+            <PivotItem Header="Dev" Name="Dev">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="Auto"/>
+                    </Grid.ColumnDefinitions>
+                    <StackPanel Grid.Column="0">
+                        <Button Content="Set Init to false" Click="SetInitToFalse" Width="200"/>
+                        <Button Content="Throw exception" Click="ThrowException" Width="200"/>
+                        <Button Content="Attach Elmah" Click="AttachElmah" Width="200"/>
+                        <Button Content="Run InstallService" Click="Reinstall" Width="200"/>
                     </StackPanel>
-                    <StackPanel Orientation="Horizontal" VerticalAlignment="Bottom">
-                        <TextBlock Name="cpuarch"/>
-                        <TextBlock Name="osarch" Margin="10,0"/>
-                        <TextBlock Name="osinfo"/>
-                        <TextBlock Name="Last"/>
+                    <StackPanel VerticalAlignment="Bottom" Grid.Column="1" Margin="10,0,0,0">
+                        <TextBlock Name="CPUArchitecture"/>
+                        <TextBlock Name="OSArchitecture"/>
+                        <TextBlock Name="OSInfo"/>
+                        <TextBlock Name="AppArchitecture"/>
                     </StackPanel>
+                </Grid>
 
-                    <TextBlock Name="apparch"/>
-                </StackPanel>
             </PivotItem>
         </Pivot>
         <TextBlock Text="Changing these settings may require a restart to take effect." HorizontalAlignment="Center" VerticalAlignment="Bottom" Margin="0,15,0,0"/>

--- a/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
+++ b/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml.cs
@@ -27,20 +27,24 @@ public sealed partial class PreferencesDialog : Page
         Version.Text = "StoryBuilder Version: " + Package.Current.Id.Version.Major + "." + Package.Current.Id.Version.Minor + "." + Package.Current.Id.Version.Build + "." + Package.Current.Id.Version.Revision;
         SetChangelog();
 
-        if (Debugger.IsAttached || GlobalData.Preferences.Name == "ShowMeTheDevTab")
+        //TODO: Put this in a VM and make this data get logged at start up with some more system info.
+        if (Debugger.IsAttached)
         {
-            Dev.IsEnabled = true;
-            Dev.Opacity = 1;
-            Dev.Header = "Dev";
-            cpuarch.Text = "CPU ARCH: " + RuntimeInformation.ProcessArchitecture;
-            osarch.Text = "OS ARCH: " + RuntimeInformation.OSArchitecture;
-            //LastContact.Text = "Last Contact: " + GlobalData.Preferences.;
-            osinfo.Text = "OS INFO: Windows Build " + Environment.OSVersion.VersionString.Replace("Microsoft Windows NT 10.0.","").Replace(".0","");
-            if (IntPtr.Size == 4) { apparch.Text = "Looks like we are running as a 32 bit process."; }
-            else if (IntPtr.Size == 8) { apparch.Text = "Looks like we are running as a 64 bit process."; }
-            else { apparch.Text = $"We don't know what architecture we are running on,\nMight want to call for help.\nIntPtr was {IntPtr.Size}, expected 4 or 8."; }
+            CPUArchitecture.Text = "CPU ARCH: " + RuntimeInformation.ProcessArchitecture;
+            OSArchitecture.Text = "OS ARCH: " + RuntimeInformation.OSArchitecture;
+            OSInfo.Text = "OS Info: Windows Build " + Environment.OSVersion.VersionString.Replace("Microsoft Windows NT 10.0.","").Replace(".0","");
+            if (IntPtr.Size == 4) { AppArchitecture.Text = "We are running as a 32 bit process."; }
+            else if (IntPtr.Size == 8) { AppArchitecture.Text = "We are running as a 64 bit process."; }
+            else { AppArchitecture.Text = $"UNKNOWN ARCHITECTURE!\nIntPtr was {IntPtr.Size}, expected 4 or 8."; }
         }
-        else { PivotView.Items.Remove(Dev); }
+        else
+        {
+            Dev.Header = "";
+            Dev.Content = null;
+            Dev.IsEnabled = false;
+            Dev.Opacity = 0;
+            PivotView.Items.Remove(Dev);
+        }
     }
 
     private async void SetChangelog()


### PR DESCRIPTION
This PR enables single instancing, which means that only 1 instance of storybuilder can be open at once.
If another instance is opened whilst one is already open then it will bring the first instance into view and then terminate the second instance.

This PR Fixes #43 

NOTE: THIS CANNOT BE TESTED WITHIN VS!
To test:
- Open the app within vs then close it.
- Open the app from the taskbar/startmenu
- Try and open another instance from taskbar/startmenu.

Side note this PR also makes the following changes to the Dev menu
- Cleans up some Dev Menu XAML.
- Stops some dev menu info from cutting off.
- Removes ShowMeTheDevTab entry into dev menu, a debugger must be attached to see the dev menu now.