### PR TITLE
Null fixes

### DIFF
--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -27,6 +27,7 @@ using System.Runtime.InteropServices;
 using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.Pickers;
+using Elmah.Io.Client;
 using StoryBuilder.Services;
 using WinRT;
 using GuidAttribute = System.Runtime.InteropServices.GuidAttribute;
@@ -848,6 +849,14 @@ namespace StoryBuilder.ViewModels
             Messenger.Send(new StatusChangedMessage(new($"Save File As command executing", LogLevel.Info, true)));
             try
             {
+                if (StoryModel.ProjectFile == null || StoryModel.ProjectPath == null)
+                {
+                    Messenger.Send(new StatusChangedMessage(new($"You need to load a story first!", LogLevel.Info, false)));
+                    Logger.Log(LogLevel.Warn, "User tried to use save as without a story loaded.");
+                    _canExecuteCommands = true;
+                    return;
+                }
+
                 //Creates the content diolouge
                 ContentDialog SaveAsDialog = new();
                 SaveAsDialog.Title = "Save as";

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -769,7 +769,7 @@ namespace StoryBuilder.ViewModels
         }
         public async Task SaveFile()
         {
-            if (DataSource.Count == 0 || DataSource == null)
+            if (DataSource == null || DataSource.Count == 0)
             {
                 Messenger.Send(new StatusChangedMessage(new($"You need to open a story first!", LogLevel.Info, false)));
                 Logger.Log(LogLevel.Info, "SaveFile command cancelled (DataSource was null or empty)");

--- a/StoryBuilderLib/ViewModels/Tools/NarrativeToolVM.cs
+++ b/StoryBuilderLib/ViewModels/Tools/NarrativeToolVM.cs
@@ -147,6 +147,11 @@ public class NarrativeToolVM: ObservableRecipient
     /// </summary>
     private void MakeSection()
     {
+        if (ShellVM.DataSource == null || ShellVM.DataSource.Count > 0)
+        {
+            Logger.Log(LogLevel.Warn, "DataSource is empty or null, not adding section");
+            return;
+        }
         _ = new StoryNodeItem(new SectionModel(FlyoutText, ShellVM.StoryModel), ShellVM.StoryModel.NarratorView[0]);
     }
 


### PR DESCRIPTION
This branch fixes 3 issues surrounding nullref errors

- #403 by switching the order of the check used to see if a story is loaded
- #404 by checking the storymodel has a path set
- #405 by ensuring the datasource isn't null.