### PR TITLE
Tweak preferences related things

### DIFF
--- a/StoryBuilder/Views/Shell.xaml
+++ b/StoryBuilder/Views/Shell.xaml
@@ -324,8 +324,7 @@
                         <KeyboardAccelerator Modifiers="Control" Key="P"/>
                     </AppBarButton.KeyboardAccelerators>
                 </AppBarButton>
-                <AppBarButton Label="Help" ToolTipService.ToolTip="Help"
-                              Command="{x:Bind ShellVm.HelpCommand, Mode=OneWay}" >
+                <AppBarButton Label="Help" ToolTipService.ToolTip="Help" Command="{x:Bind ShellVm.HelpCommand, Mode=OneWay}" >
                     <AppBarButton.Icon>
                         <FontIcon FontFamily="Segoe MDL2 Assets" Glyph="&#xE897;"/>
                     </AppBarButton.Icon>

--- a/StoryBuilderLib/DAL/PreferencesIO.cs
+++ b/StoryBuilderLib/DAL/PreferencesIO.cs
@@ -135,7 +135,7 @@ public class PreferencesIo
                             _model.RecordVersionStatus = false;
                         break;
                     case "WrapNodeNames":
-                        if (_tokens[1] == "True") { _model.WrapNodeNames = TextWrapping.Wrap; }
+                        if (_tokens[1] == "True") { _model.WrapNodeNames = TextWrapping.WrapWholeWords; }
                         else { _model.WrapNodeNames = TextWrapping.NoWrap; }
                         break;
                     case "AutoSave":

--- a/StoryBuilderLib/Models/Tools/PreferencesModel.cs
+++ b/StoryBuilderLib/Models/Tools/PreferencesModel.cs
@@ -34,7 +34,7 @@ public class PreferencesModel
     /// installation. 
     /// </summary>
     public bool PreferencesInitialized { get; set; }
-    public int LastSelectedTemplate { get; set; } //This is the Last Template Selected by the user.3
+    public int LastSelectedTemplate { get; set; } //This is the Last Template Selected by the user.
 
     // Visual changes
     public SolidColorBrush PrimaryColor { get; set; } //Sets UI Color
@@ -76,6 +76,12 @@ public class PreferencesModel
         LastFile3 = string.Empty;
         LastFile4 = string.Empty;
         LastFile5 = string.Empty;
+        AutoSave = true;
+        TimedBackup = true;
+        PreferredSearchEngine = BrowserType.DuckDuckGo;
+        AutoSaveInterval = 5;
+        TimedBackupInterval = 5;
+        WrapNodeNames = TextWrapping.WrapWholeWords;
     }
     #endregion
 }

--- a/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml
+++ b/StoryBuilderLib/Services/Dialogs/Tools/PreferencesDialog.xaml
@@ -32,8 +32,9 @@
                     <CheckBox Content="Send me newsletters about StoryBuilder" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.NewsConsent, Mode=TwoWay}"/>
                     <CheckBox Content="Wrap node names" Margin="8" HorizontalAlignment="Left" IsChecked="{x:Bind PreferencesVm.WrapNodeNames, Mode=TwoWay}"/>
                     <StackPanel Orientation="Horizontal">
-                        <CheckBox Content="Automatically Save" IsChecked="{x:Bind PreferencesVm.AutoSave, Mode=TwoWay}" HorizontalAlignment="Left" Margin="8"/>
+                        <CheckBox Content="Automatically Save every" IsChecked="{x:Bind PreferencesVm.AutoSave, Mode=TwoWay}" HorizontalAlignment="Left" Margin="8"/>
                         <NumberBox Minimum="5" Maximum="60" IsEnabled="{x:Bind PreferencesVm.AutoSave, Mode=TwoWay}" PlaceholderText="Enter a value (Seconds)" Value="{x:Bind PreferencesVm.AutoSaveInterval, Mode=TwoWay}" HorizontalAlignment="Left" Margin="8"/>
+                        <TextBlock Text="Seconds" VerticalAlignment="Center" HorizontalAlignment="Center"/>
                     </StackPanel>
                     <ComboBox Header="Preferred Search Engine" HorizontalAlignment="Stretch" SelectedIndex="{x:Bind PreferencesVm.PreferredSearchEngine, Mode=TwoWay}">
                         <ComboBoxItem Content="DuckDuckGo"/>

--- a/StoryBuilderLib/ViewModels/Tools/InitVM.cs
+++ b/StoryBuilderLib/ViewModels/Tools/InitVM.cs
@@ -5,11 +5,18 @@ using StoryBuilder.DAL;
 using StoryBuilder.Models;
 using StoryBuilder.Models.Tools;
 using StoryBuilder.Services.Backend;
+using System;
 
 namespace StoryBuilder.ViewModels.Tools;
 
 public class InitVM : ObservableRecipient
 {
+    public InitVM()
+    {
+       _path = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "StoryBuilder", "Projects");
+       _Backuppath = System.IO.Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments), "StoryBuilder", "Backups");
+    } 
+
     private string _errorMessage;
     public string ErrorMessage
     {
@@ -68,7 +75,11 @@ public class InitVM : ObservableRecipient
         prf.ProjectDirectory = Path;
         prf.BackupDirectory = BackupPath;
         prf.Name = Name;
-        prf.PreferencesInitialized = true; //Makes sure this window isn't shown to the user
+        prf.PreferencesInitialized = true; //Makes sure this window isn't shown to the user again
+
+        //Create paths
+        System.IO.Directory.CreateDirectory(Path);
+        System.IO.Directory.CreateDirectory(BackupPath);
 
         //Updates the file, then rereads into memory.
         PreferencesIo prfIO = new(prf, System.IO.Path.Combine(ApplicationData.Current.RoamingFolder.Path,"Storybuilder"));
@@ -76,7 +87,6 @@ public class InitVM : ObservableRecipient
         PreferencesIo loader = new(GlobalData.Preferences, System.IO.Path.Combine(ApplicationData.Current.RoamingFolder.Path, "Storybuilder"));
         await loader.UpdateModel();
         BackendService backend = Ioc.Default.GetService<BackendService>();
-        if (!GlobalData.Preferences.RecordPreferencesStatus)
-            await backend.PostPreferences(GlobalData.Preferences);
+        if (!GlobalData.Preferences.RecordPreferencesStatus) { await backend.PostPreferences(GlobalData.Preferences); }
     }
 }

--- a/StoryBuilderLib/ViewModels/Tools/PreferencesViewModel.cs
+++ b/StoryBuilderLib/ViewModels/Tools/PreferencesViewModel.cs
@@ -8,6 +8,7 @@ using StoryBuilder.DAL;
 using StoryBuilder.Models;
 using StoryBuilder.Models.Tools;
 using StoryBuilder.Services.Backend;
+using System;
 
 namespace StoryBuilder.ViewModels.Tools;
 


### PR DESCRIPTION
This PR makes a lot of small tweaks to preferences:
- Fixes an issue relating to node name wrapping not saving
- Set the following as default settings: (some might be on by default anyway.)
Autosaving is on by default with a default interval of 5 seconds, 
Timed backup now defaults to 5 minutes
Wrapped node names is now on by default
The default search engine is now DuckDuckGo
- Tweaked UI of the AutoSave box to show Seconds to the side of the seconds box
- Initalizeation now has defaults set for both the projects and backup paths
   C:\Users\[USERNAME]\Documents\StoryBuilder\Projects
   C:\Users\[USERNAME]\Documents\StoryBuilder\Backups
