### PR TITLE
Bump relevant projects to WinAppSDK 1.2

### DIFF
--- a/StoryBuilder/StoryBuilder.csproj
+++ b/StoryBuilder/StoryBuilder.csproj
@@ -38,7 +38,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="dotenv.net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.220930.4-preview2" />
+		<PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
 		<PackageReference Include="Microsoft.Windows.SDK.BuildTools" Version="10.0.22621.1" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.0.0-preview2" />
 		<PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />

--- a/StoryBuilderLib/StoryBuilderLib.csproj
+++ b/StoryBuilderLib/StoryBuilderLib.csproj
@@ -69,7 +69,7 @@
     <PackageReference Include="CommunityToolkit.WinUI.UI.Controls.Core" Version="7.1.2" />
     <PackageReference Include="dotenv.net" Version="3.1.1" />
     <PackageReference Include="Elmah.Io.NLog" Version="4.1.25" />
-    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.220930.4-preview2" />
+    <PackageReference Include="Microsoft.WindowsAppSDK" Version="1.2.221109.1" />
     <PackageReference Include="MySql.Data" Version="8.0.30" />
     <PackageReference Include="NLog" Version="5.0.1" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.0.1" />


### PR DESCRIPTION
This PR bumps relvant projects (StoryBuilder and StoryBuilderLib) to use Windows App SDK 1.2 from the preview.