### PR TITLE
Bump to .NET7 & Fix CI/CD Warnings

### DIFF
--- a/.github/workflows/AutoBuilder.yml
+++ b/.github/workflows/AutoBuilder.yml
@@ -26,13 +26,13 @@ jobs:
 
     # Install .NET
     - name: Install .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: 7.x.x
 
     #Install MSBUILD
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
     
     - uses: oprypin/find-latest-tag@v1
       with:
@@ -119,7 +119,7 @@ jobs:
     
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload MSIX package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: StoryBuilder
         path: D:\a\StoryBuilder-2\StoryBuilder-2\StoryBuilder\Packages\*

--- a/.github/workflows/AutoBuilder.yml
+++ b/.github/workflows/AutoBuilder.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Download Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
@@ -28,7 +28,7 @@ jobs:
     - name: Install .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.x.x
 
     #Install MSBUILD
     - name: Setup MSBuild.exe

--- a/.github/workflows/ReleaseBuilder.yml
+++ b/.github/workflows/ReleaseBuilder.yml
@@ -15,19 +15,19 @@ jobs:
 
     steps:
     - name: Download Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         fetch-depth: 0
 
     # Install .NET
     - name: Install .NET
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 6.0.x
+        dotnet-version: 7.x.x
 
     #Install MSBUILD
     - name: Setup MSBuild.exe
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1
 
     #Bump version number
     - name: Increase Version Number 
@@ -115,7 +115,7 @@ jobs:
 
     # Upload the MSIX package: https://github.com/marketplace/actions/upload-a-build-artifact
     - name: Upload MSIX package
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: StoryBuilder
         path: D:\a\StoryBuilder-2\StoryBuilder-2\StoryBuilder\Packages\*

--- a/NRtfTree/NRtfTree.csproj
+++ b/NRtfTree/NRtfTree.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<RuntimeIdentifiers>win10-x86;win10-x64</RuntimeIdentifiers>
-		<TargetFramework>net6.0</TargetFramework>
+		<TargetFramework>net7.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17134.0</TargetPlatformMinVersion>
 		<OutputType>Library</OutputType>
 		<RuntimeIdentifiers>win10-x86;win10-x64</RuntimeIdentifiers>

--- a/StoryBuilder/StoryBuilder.csproj
+++ b/StoryBuilder/StoryBuilder.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	<PropertyGroup>
 		<OutputType>WinExe</OutputType>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
 		<TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
 		<RootNamespace>StoryBuilder</RootNamespace>
 		<ApplicationManifest>app.manifest</ApplicationManifest>

--- a/StoryBuilderLib/StoryBuilderLib.csproj
+++ b/StoryBuilderLib/StoryBuilderLib.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-	  <TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+	  <TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
     <TargetPlatformMinVersion>10.0.17763.0</TargetPlatformMinVersion>
     <RootNamespace>StoryBuilder</RootNamespace>
     <RuntimeIdentifiers>win10-x86;win10-x64</RuntimeIdentifiers>

--- a/StoryBuilderTests/StoryBuilderTests.csproj
+++ b/StoryBuilderTests/StoryBuilderTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFramework>net6.0-windows10.0.19041.0</TargetFramework>
+		<TargetFramework>net7.0-windows10.0.19041.0</TargetFramework>
 		<RootNamespace>TemplateTest.Tests.MSTest</RootNamespace>
 		<Platforms>x86;x64;arm64</Platforms>
 		<IsPackable>false</IsPackable>


### PR DESCRIPTION
This bumps all our projects to use .NET7,
This also bumps the version of some of the CI/CD scripts we use as they are becoming deprechiated.