### PR TITLE
Fix Async Issues when installing WebView Runtime.

### DIFF
--- a/StoryBuilder/Views/Shell.xaml.cs
+++ b/StoryBuilder/Views/Shell.xaml.cs
@@ -56,7 +56,9 @@ public sealed partial class Shell
 
         if (!await Ioc.Default.GetRequiredService<WebViewModel>().CheckWebviewState())
         {
+            ShellVm._canExecuteCommands = false;
             await Ioc.Default.GetRequiredService<WebViewModel>().ShowWebviewDialog();
+            ShellVm._canExecuteCommands = true;
         }
         if (GlobalData.LoadedWithVersionChange ) { await ShellVm.ShowChangelog(); }
         await ShellVm.OpenUnifiedMenu();

--- a/StoryBuilderLib/ViewModels/ShellViewModel.cs
+++ b/StoryBuilderLib/ViewModels/ShellViewModel.cs
@@ -44,7 +44,7 @@ namespace StoryBuilder.ViewModels;
 
 public class ShellViewModel : ObservableRecipient
 {
-    private bool _canExecuteCommands;
+    public bool _canExecuteCommands;
 
     private const string HomePage = "HomePage";
     private const string OverviewPage = "OverviewPage";

--- a/StoryBuilderLib/ViewModels/WebViewModel.cs
+++ b/StoryBuilderLib/ViewModels/WebViewModel.cs
@@ -136,13 +136,13 @@ public class WebViewModel : ObservableRecipient, INavigable
         _logger.Log(LogLevel.Error, $"User clicked {_result}");
 
         //Ok clicked
-        if (_result == ContentDialogResult.Primary) { InstallWebview(); }
+        if (_result == ContentDialogResult.Primary) { await InstallWebview(); }
     }
 
     /// <summary>
     /// This installs the evergreen webview runtime
     /// </summary>
-    public async void InstallWebview()
+    public async Task InstallWebview()
     {
         Ioc.Default.GetRequiredService<LogService>().Log(LogLevel.Error, "Installing webview...");
 


### PR DESCRIPTION
This PR fixes an Async Error caused by too many content dialogs opening at once during the webview run time install.

Before this PR, we would ask the user if they want to install the webview runtime, if they clicked yes we would install and show a content dialog when it's done saying its either successfully installed or an error occured. 

This leads to issue that another content dialog that shows on startup such as the changelog or the OpenFile menu would be open for this second popup leading to an async error.

We also now prevent the user from opening files ect, until the install code has finished executing.