### PR TITLE
Allow relationships to have text input

### DIFF
--- a/StoryBuilderLib/Services/Dialogs/NewRelationshipPage.xaml
+++ b/StoryBuilderLib/Services/Dialogs/NewRelationshipPage.xaml
@@ -10,7 +10,7 @@
         <StackPanel Orientation="Horizontal" Width="500" HorizontalAlignment="Center">
             <TextBlock  Text="{x:Bind CharVM.Name}" VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
             <TextBlock  Text=" is a " VerticalAlignment="Center" Margin="0,0,5,0"/>
-            <ComboBox  MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" SelectedItem="{x:Bind  NewRelVM.RelationType, Mode=TwoWay}" Margin="0,10" VerticalAlignment="Center"/>
+            <ComboBox  MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.RelationType, Mode=TwoWay}" Margin="0,10" VerticalAlignment="Center"/>
             <TextBlock  Text=" to " VerticalAlignment="Center" Margin="5,0"/>
             <ComboBox Name="PartnerBox" IsEditable="False" MinWidth="150" ItemsSource="{x:Bind NewRelVM.ProspectivePartners}" DisplayMemberPath="Name" SelectedItem="{x:Bind  NewRelVM.SelectedPartner, Mode=TwoWay}" VerticalAlignment="Center"/>
         </StackPanel>
@@ -19,7 +19,7 @@
         <StackPanel Orientation="Horizontal" Width="500" HorizontalAlignment="Center">
             <TextBlock Text="{x:Bind  NewRelVM.SelectedPartner.Name, Mode=TwoWay}" VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
             <TextBlock  Text=" is a " VerticalAlignment="Center" Margin="10,0"/>
-            <ComboBox   MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" VerticalAlignment="Center"  SelectedItem="{x:Bind  NewRelVM.InverseRelationType, Mode=TwoWay}" IsEnabled="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
+            <ComboBox   MinWidth="150" ItemsSource="{x:Bind  NewRelVM.RelationTypes}" VerticalAlignment="Center" IsEditable="True"  SelectedValue="{x:Bind  NewRelVM.InverseRelationType, Mode=TwoWay}" IsEnabled="{x:Bind NewRelVM.InverseRelationship, Mode=TwoWay}"/>
             <TextBlock  Text=" to" VerticalAlignment="Center" Margin="5,0"/>
             <TextBlock  Text="{x:Bind CharVM.Name}"  VerticalAlignment="Center" MaxWidth="120" TextWrapping="Wrap"/>
         </StackPanel>


### PR DESCRIPTION
This PR just makes the comboboxes on the NewRelationship dialog to be manually editable.

This allows the user to manually specify the relationship if we haven't covered it.