### PR TITLE
Add FlushAsync() call after saving XmlDocument to XmlWriter Stream.

### DIFF
--- a/StoryBuilderLib/DAL/StoryWriter.cs
+++ b/StoryBuilderLib/DAL/StoryWriter.cs
@@ -67,6 +67,7 @@ public class StoryWriter
             try
             {
                 _xml.Save(_writer);
+                await _writer.FlushAsync();
             }
             catch (Exception _ex) { _logger.LogException(Services.Logging.LogLevel.Error,_ex, "Error in write file"); }
         }


### PR DESCRIPTION
This will hopefully correct issues writing to OneDrive and other slow cloud storage services.
Fixes issue #493.