### PR TITLE
Fix issues with print single node

### DIFF
--- a/StoryBuilderLib/ViewModels/Tools/PrintReportDialogVM.cs
+++ b/StoryBuilderLib/ViewModels/Tools/PrintReportDialogVM.cs
@@ -192,9 +192,12 @@ public class PrintReportDialogVM : ObservableRecipient
         SelectedNodes.Clear(); //Only print single node
 
         PrintReports _rpt = new(this, ShellViewModel.GetModel());
-        await _rpt.Generate();
+       
+        if (elementItem.Type == StoryItemType.StoryOverview) {CreateOverview = true; }
+        else { SelectedNodes.Add(elementItem); }
 
-        await new PrintReports(this, ShellViewModel.GetModel()).Generate();
+        _rpt.Print(await _rpt.Generate());
+        CreateOverview = false;
     }
 
     public void RegisterForPrint()


### PR DESCRIPTION
This PR fixes issues relating to single node printing:
- single node printing now should print again
- trying print an overview via the right click menu (single node printing) should work now.